### PR TITLE
[Add] Support for Data Source Whitelist

### DIFF
--- a/site24x7/data_source_ip_whitelist.go
+++ b/site24x7/data_source_ip_whitelist.go
@@ -1,0 +1,146 @@
+package site24x7
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceSite24x7IpWhitelist() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceSite24x7IpWhitelistRead,
+
+		Schema: map[string]*schema.Schema{
+			"filter": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"city": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"place": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"ipv4": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"ipv6": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceSite24x7IpWhitelistRead(d *schema.ResourceData, meta interface{}) error {
+	type Results struct {
+		LocationDetails []struct {
+			IPv6AddressExternal string `json:"IPv6_Address_External"`
+			City                string `json:"City"`
+			Place               string `json:"Place"`
+			ExternalIP          string `json:"external_ip"`
+		} `json:"LocationDetails"`
+	}
+
+	httpClient := http.Client{
+		Timeout: time.Second * 5,
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "https://creatorexport.zoho.com/site24x7/location-manager/json/IP_Address_View/C80EnP71mW2fDd60GaDgnPbVwMS8AGmP85vrN27EZ1CnCjPwnm0zPB5EX4Ct4q9n3rUnUgYwgwX0BW3KFtxnBqHt60Sz1Pgntgru", nil)
+	if err != nil {
+		return err
+	}
+
+	res, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+
+	results := Results{}
+	err = json.Unmarshal(body, &results)
+	if err != nil {
+		return err
+	}
+
+	filters := d.Get("filter").(*schema.Set).List()
+	ipv4 := make([]interface{}, 0)
+	ipv6 := make([]interface{}, 0)
+
+	if len(filters) != 0 {
+		for f := range filters {
+			city := filters[f].(map[string]interface{})["city"].(string)
+			place := filters[f].(map[string]interface{})["place"].(string)
+
+			log.Printf("City: %s, Place: %s\n", city, place)
+
+			for _, r := range results.LocationDetails {
+				if r.City == city && r.Place == place {
+					ipv4 = appendValidate(ipv4, r.ExternalIP)
+					ipv6 = appendValidate(ipv6, r.IPv6AddressExternal)
+				}
+			}
+		}
+	} else {
+		for _, r := range results.LocationDetails {
+			ipv4 = appendValidate(ipv4, r.ExternalIP)
+			ipv6 = appendValidate(ipv6, r.IPv6AddressExternal)
+		}
+
+	}
+
+	d.SetId(time.Now().UTC().String())
+	d.Set("ipv4", ipToCidr(ipv4, 32))
+	d.Set("ipv6", ipToCidr(ipv6, 128))
+
+	return nil
+}
+
+func appendValidate(arr []interface{}, val string) []interface{} {
+	if strings.Contains(val, "\n") {
+		for _, ip := range strings.Split(val, "\n") {
+			arr = append(arr, ip)
+		}
+		return arr
+	}
+
+	if strings.Contains(val, "\u200A") {
+		return append(arr, strings.TrimLeft(val, "\u200A"))
+	}
+
+	if val != "" {
+		return append(arr, val)
+	}
+
+	return arr
+}
+func ipToCidr(arr []interface{}, cidr int) (parsed []interface{}) {
+	for _, ip := range arr {
+		if strings.Contains(ip.(string), "/") {
+			parsed = append(parsed, ip)
+		} else {
+			parsed = append(parsed, fmt.Sprintf("%s/%d", ip, cidr))
+		}
+	}
+
+	return parsed
+}

--- a/site24x7/data_source_ip_whitelist_test.go
+++ b/site24x7/data_source_ip_whitelist_test.go
@@ -1,0 +1,109 @@
+package site24x7
+
+import (
+	"fmt"
+	"net"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourceSite24x7IpWhitelist_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceSite24x7IpWhitelistConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccSote24x7IpWhitelistCheck("data.site24x7_ip_whitelist.test", "ipv4"),
+					testAccSote24x7IpWhitelistCheck("data.site24x7_ip_whitelist.test", "ipv6"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceSite24x7IpWhitelist_filter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceSite24x7IpWhitelistFilterConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccSote24x7IpWhitelistCheck("data.site24x7_ip_whitelist.test", "ipv4"),
+					testAccSote24x7IpWhitelistCheck("data.site24x7_ip_whitelist.test", "ipv6"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSote24x7IpWhitelistCheck(name, key string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Can't access resource: %s", name)
+		}
+
+		attrs := rs.Primary.Attributes
+
+		v, ok := attrs[fmt.Sprintf("%s.#", key)]
+		if !ok {
+			return fmt.Errorf("%s list is missing.", key)
+		}
+
+		qty, err := strconv.Atoi(v)
+		if err != nil {
+			return err
+		}
+
+		if qty < 1 {
+			return fmt.Errorf("No %s addresses found.", key)
+		}
+
+		r := regexp.MustCompile(fmt.Sprintf("%s.[0-9]+", key))
+		var count int
+
+		for k, v := range attrs {
+			if r.MatchString(k) {
+				if strings.Contains(v, "/") {
+					_, _, err := net.ParseCIDR(v)
+					if err != nil {
+						return fmt.Errorf("Error %v , '%s' is not a valid IP address", err, v)
+					}
+				} else {
+					if net.ParseIP(v) == nil {
+						return fmt.Errorf(" '%s' is not a valid IP address", v)
+					}
+				}
+				count++
+			}
+		}
+
+		fmt.Printf("Found %d %s addresses\n", count, key)
+		return nil
+	}
+}
+
+func testAccDataSourceSite24x7IpWhitelistConfig() string {
+	return fmt.Sprintf(`
+data "site24x7_ip_whitelist" "test" {}
+`)
+}
+
+func testAccDataSourceSite24x7IpWhitelistFilterConfig() string {
+	return fmt.Sprintf(`
+data "site24x7_ip_whitelist" "test" {
+  filter {
+    city = "Denver"
+    place = "US"
+  }
+}
+`)
+}

--- a/site24x7/provider.go
+++ b/site24x7/provider.go
@@ -14,8 +14,11 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("SITE24X7_AUTHTOKEN", nil),
-				Description: "Username for StatusCake Account.",
+				Description: "Authorization Token for Site24x7.",
 			},
+		},
+		DataSourcesMap: map[string]*schema.Resource{
+			"site24x7_ip_whitelist": dataSourceSite24x7IpWhitelist(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{


### PR DESCRIPTION
This adds support for discovery of whitelisted IP addresses.

All IP addresses can be retrieved with
```
data "site24x7_ip_whitelist" "all" {}
```

or 1 or more filters can be applied
```
data "site24x7_ip_whitelist" "den_sfo" {
  filter {
    city = "Denver"
    place = "US"
  }

  filter {
    city = "San Francisco"
    place = "US"
  }
}
```

Please let me know if you have any questions.