### PR TITLE
oauth2: client id, client secret and refresh token do not expire

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,37 +1,28 @@
 package main
 
 import (
-	"log"
-	"os"
-	"path/filepath"
-
 	"github.com/hashicorp/terraform/plugin"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/sourcegraph/terraform-provider-site24x7/site24x7"
-	"github.com/sourcegraph/terraform-provider-site24x7/site24x7/oauth"
 )
 
 // main is a plugin main, not a "real" main.
-// Please set the value of environment variable SITE24X7_AUTHTOKEN_FILE to a path to a JSDN file (file does not need to exist, it gets created if it doesn't).
-// This JSDN file stores the OAuth2 tokens from site24x7. If you don't set this environment variable it will use path `.size24x7_auth.json`.
+// Please set the value of environment variable `SITE24X7_AUTHTOKEN_FILE` to a path to a JSDN file
+// This JSDN file stores the client id, client secret and refresh token necessary to obtain OAuth2 access tokens from
+// site24x7. Expected is the following content for the JSON file:
+//
+// {
+//    "CLIENT_ID": "xxxx_your_client_id_xxxxx",
+//    "CLIENT_SECRET": "xxxx_your_client_secret_xxxxx",
+//    "REFRESH_TOKEN": "xxxx_your_refresh_token_xxxxx",
+// }
+//
+// If `SITE24X7_AUTHTOKEN_FILE` is not set it will use `site24x7-oauth.json` in the current working directory.
+// A helper command in site24x7/oauth/cmd/site24x7-oauth can be used to generate the JSON file.
 func main() {
-	oauthFile, ok := os.LookupEnv("SITE24X7_AUTHTOKEN_FILE")
-	if !ok {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			log.Fatal(err)
-		}
-		oauthFile = filepath.Join(homeDir, ".size24x7_auth.json")
-	}
-
-	ator, err := oauth.NewAuthenticator(oauthFile)
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: func() terraform.ResourceProvider {
-			return site24x7.Provider(ator)
+			return site24x7.Provider()
 		},
 	})
 }

--- a/main.go
+++ b/main.go
@@ -6,19 +6,6 @@ import (
 	"github.com/sourcegraph/terraform-provider-site24x7/site24x7"
 )
 
-// main is a plugin main, not a "real" main.
-// Please set the value of environment variable `SITE24X7_AUTHTOKEN_FILE` to a path to a JSDN file
-// This JSDN file stores the client id, client secret and refresh token necessary to obtain OAuth2 access tokens from
-// site24x7. Expected is the following content for the JSON file:
-//
-// {
-//    "CLIENT_ID": "xxxx_your_client_id_xxxxx",
-//    "CLIENT_SECRET": "xxxx_your_client_secret_xxxxx",
-//    "REFRESH_TOKEN": "xxxx_your_refresh_token_xxxxx",
-// }
-//
-// If `SITE24X7_AUTHTOKEN_FILE` is not set it will use `site24x7-oauth.json` in the current working directory.
-// A helper command in site24x7/oauth/cmd/site24x7-oauth can be used to generate the JSON file.
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: func() terraform.ResourceProvider {

--- a/site24x7/oauth/cmd/site24x7-oauth/main.go
+++ b/site24x7/oauth/cmd/site24x7-oauth/main.go
@@ -1,30 +1,53 @@
 package main
 
 import (
-	"log"
+	"encoding/json"
+	"flag"
+	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/sourcegraph/terraform-provider-site24x7/site24x7/oauth"
 )
 
+type oauthData struct {
+	ClientId            string  `json:"CLIENT_ID"`
+	ClientSecret        string  `json:"CLIENT_SECRET"`
+	RefreshToken        string  `json:"REFRESH_TOKEN"`
+}
+
+var (
+	clientId = flag.String("clientId", "", "(required) client id")
+	clientSecret = flag.String("clientSecret", "", "(required) client secret")
+	generateCode = flag.String("generateCode", "", "(required) generate code token")
+)
+
 func main() {
-	var oauthFile string
+	flag.Parse()
 
-	if len(os.Args) != 2 {
-		homeOir, err := os.UserHomeDir()
-		if err != nil {
-			log.Fatal(err)
-		}
-		oauthFile = filepath.Join(homeOir, ".site24x7-oauth.json")
-	} else {
-		oauthFile = os.Args[1]
+	if *clientId == "" || *clientSecret == "" || *generateCode == "" {
+		fmt.Fprintln(os.Stderr, "Follow the instructions at https://www.site24x7.com/help/api/index.html#authentication to obtain a client id, client secret and generate code")
+		flag.PrintDefaults()
+		os.Exit(2)
 	}
 
-	_, err := oauth.NewAuthenticator(oauthFile)
+	refreshToken, err := oauth.GenerateRefreshToken(*clientId, *clientSecret, *generateCode)
 	if err != nil {
-		log.Fatal(err)
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 
-	log.Printf("set env var SITE24X7_AUTHTOKEN_FILE=%s", oauthFile)
+	oad := &oauthData{
+		ClientId:     *clientId,
+		ClientSecret: *clientSecret,
+		RefreshToken: refreshToken,
+	}
+
+	contents, err := json.MarshalIndent(oad, "", " ")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+
+	}
+
+	fmt.Println(string(contents))
 }

--- a/site24x7/oauth/cmd/site24x7-oauth/main.go
+++ b/site24x7/oauth/cmd/site24x7-oauth/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -10,13 +9,13 @@ import (
 )
 
 type oauthData struct {
-	ClientId            string  `json:"CLIENT_ID"`
-	ClientSecret        string  `json:"CLIENT_SECRET"`
-	RefreshToken        string  `json:"REFRESH_TOKEN"`
+	ClientId     string
+	ClientSecret string
+	RefreshToken string
 }
 
 var (
-	clientId = flag.String("clientId", "", "(required) client id")
+	clientId     = flag.String("clientId", "", "(required) client id")
 	clientSecret = flag.String("clientSecret", "", "(required) client secret")
 	generateCode = flag.String("generateCode", "", "(required) generate code token")
 )
@@ -42,12 +41,7 @@ func main() {
 		RefreshToken: refreshToken,
 	}
 
-	contents, err := json.MarshalIndent(oad, "", " ")
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-
-	}
-
-	fmt.Println(string(contents))
+	fmt.Println("oauth_client_id = " + oad.ClientId)
+	fmt.Println("oauth_client_secret = " + oad.ClientSecret)
+	fmt.Println("oauth_refresh_token = " + oad.RefreshToken)
 }

--- a/site24x7/oauth/tokens.go
+++ b/site24x7/oauth/tokens.go
@@ -1,8 +1,6 @@
 package oauth
 
 import (
-	"encoding/json"
-	"io/ioutil"
 	"net/url"
 	"time"
 )
@@ -33,29 +31,6 @@ func (tkns *tokens) generatedCodeURLValues() url.Values {
 	urlValues.Set("code", tkns.GeneratedCode)
 	urlValues.Set("grant_type", "authorization_code")
 	return urlValues
-}
-
-func (tkns *tokens) persist(path string) error {
-	contents, err := json.MarshalIndent(tkns, "", " ")
-	if err != nil {
-		return err
-	}
-	return ioutil.WriteFile(path, contents, 0644)
-}
-
-func load(path string) (*tokens, error) {
-	contents, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-
-	var tkns tokens
-
-	err = json.Unmarshal(contents, &tkns)
-	if err != nil {
-		return nil, err
-	}
-	return &tkns, nil
 }
 
 func (tkns *tokens) expired() bool {

--- a/site24x7/provider.go
+++ b/site24x7/provider.go
@@ -2,8 +2,6 @@ package site24x7
 
 import (
 	"net/http"
-	"os"
-	"path/filepath"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
@@ -11,41 +9,22 @@ import (
 )
 
 func Provider() terraform.ResourceProvider {
-	// these two are captured by the DefaultFunc closure below
-	var authenticator *oauth.Authenticator
-	var oauthErr error
-
-	oauthFile, ok := os.LookupEnv("SITE24X7_AUTHTOKEN_FILE")
-	if !ok {
-		currentDir, err := os.Getwd()
-		if err != nil {
-			oauthErr = err
-		}
-		oauthFile = filepath.Join(currentDir, "site24x7-oauth.json")
-	}
-
-	if oauthErr == nil {
-		ator, err := oauth.NewAuthenticator(oauthFile)
-		if err != nil {
-			oauthErr = err
-		} else {
-			authenticator = ator
-		}
-	}
-
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
-			"oauthtoken": {
-				Type:     schema.TypeString,
-				Required: true,
-				DefaultFunc: func() (i interface{}, err error) {
-					if oauthErr != nil {
-						return nil, oauthErr
-					}
-					accessToken := authenticator.AccessToken()
-					return accessToken, nil
-				},
-				Description: "Username for StatusCake Account.",
+			"oauth_client_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Zoho Site24x7 OAuth2 client id.",
+			},
+			"oauth_client_secret": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Zoho Site24x7 OAuth2 client secret.",
+			},
+			"oauth_refresh_token": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Zoho Site24x7 OAuth2 refresh token.",
 			},
 		},
 
@@ -58,8 +37,17 @@ func Provider() terraform.ResourceProvider {
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+	clientId := d.Get("oauth_client_id").(string)
+	clientSecret := d.Get("oauth_client_secret").(string)
+	refreshToken := d.Get("oauth_refresh_token").(string)
+
+	ator, err := oauth.NewAuthenticator(clientId, clientSecret, refreshToken)
+	if err != nil {
+		return nil, err
+	}
+
 	h := make(http.Header)
-	h.Set("Authorization", "Zoho-oauthtoken "+d.Get("oauthtoken").(string))
+	h.Set("Authorization", "Zoho-oauthtoken "+ator.AccessToken())
 	return &http.Client{
 		Transport: &staticHeaderTransport{
 			base:   http.DefaultTransport,

--- a/site24x7/provider.go
+++ b/site24x7/provider.go
@@ -28,6 +28,7 @@ func Provider() terraform.ResourceProvider {
 		ator, err := oauth.NewAuthenticator(oauthFile)
 		if err != nil {
 			oauthErr = err
+		} else {
 			authenticator = ator
 		}
 	}

--- a/site24x7/provider_test.go
+++ b/site24x7/provider_test.go
@@ -29,7 +29,7 @@ func TestProvider_impl(t *testing.T) {
 }
 
 func testAccPreCheck(t *testing.T) {
-	if v := os.Getenv("SITE24X7_AUTHTOKEN"); v == "" {
-		t.Fatal("SITE24X7_AUTHTOKEN must be set for acceptance tests")
+	if v := os.Getenv("SITE24X7_AUTHTOKEN_FILE"); v == "" {
+		t.Fatal("SITE24X7_AUTHTOKEN_FILE must be set for acceptance tests")
 	}
 }

--- a/site24x7/provider_test.go
+++ b/site24x7/provider_test.go
@@ -1,7 +1,6 @@
 package site24x7
 
 import (
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -29,7 +28,4 @@ func TestProvider_impl(t *testing.T) {
 }
 
 func testAccPreCheck(t *testing.T) {
-	if v := os.Getenv("SITE24X7_AUTHTOKEN_FILE"); v == "" {
-		t.Fatal("SITE24X7_AUTHTOKEN_FILE must be set for acceptance tests")
-	}
 }


### PR DESCRIPTION
PR changes the way the OAuth2 handshake works to be more convenient for terraform users.
Once they have a JSON file with client id, client secret and refresh token they do not need to add additional steps to their terraform interactions anymore.

The small cmd in oauth/cmd/site24x7-oauth changed to make it easy to create that JSON file.

This addresses @keegancsmith feedback in a different PR (where we use the provider).