### PR TITLE
Remove use of ioutil package

### DIFF
--- a/vendor/cloud.google.com/go/compute/metadata/metadata.go
+++ b/vendor/cloud.google.com/go/compute/metadata/metadata.go
@@ -201,7 +201,7 @@ func systemInfoSuggestsGCE() bool {
 		// We don't have any non-Linux clues available, at least yet.
 		return false
 	}
-	slurp, _ := ioutil.ReadFile("/sys/class/dmi/id/product_name")
+	slurp, _ := os.ReadFile("/sys/class/dmi/id/product_name")
 	name := strings.TrimSpace(string(slurp))
 	return name == "Google" || name == "Google Compute Engine"
 }
@@ -312,7 +312,7 @@ func (c *Client) getETag(suffix string) (value, etag string, err error) {
 	if res.StatusCode == http.StatusNotFound {
 		return "", "", NotDefinedError(suffix)
 	}
-	all, err := ioutil.ReadAll(res.Body)
+	all, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", "", err
 	}

--- a/vendor/cloud.google.com/go/storage/reader.go
+++ b/vendor/cloud.google.com/go/storage/reader.go
@@ -143,7 +143,7 @@ func (o *ObjectHandle) NewRangeReader(ctx context.Context, offset, length int64)
 				return ErrObjectNotExist
 			}
 			if res.StatusCode < 200 || res.StatusCode > 299 {
-				body, _ := ioutil.ReadAll(res.Body)
+				body, _ := io.ReadAll(res.Body)
 				res.Body.Close()
 				return &googleapi.Error{
 					Code:   res.StatusCode,
@@ -270,7 +270,7 @@ func parseCRC32c(res *http.Response) (uint32, bool) {
 	return 0, false
 }
 
-var emptyBody = ioutil.NopCloser(strings.NewReader(""))
+var emptyBody = io.NopCloser(strings.NewReader(""))
 
 // Reader reads a Cloud Storage object.
 // It implements io.Reader.

--- a/vendor/github.com/aws/aws-sdk-go/aws/client/logger.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/client/logger.go
@@ -144,7 +144,7 @@ func logResponse(r *request.Request) {
 			req.ClientInfo.ServiceName, req.Operation.Name, string(b)))
 
 		if logBody {
-			b, err := ioutil.ReadAll(lw.buf)
+			b, err := io.ReadAll(lw.buf)
 			if err != nil {
 				lw.Logger.Log(fmt.Sprintf(logRespErrMsg,
 					req.ClientInfo.ServiceName, req.Operation.Name, err))

--- a/vendor/github.com/aws/aws-sdk-go/aws/corehandlers/handlers.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/corehandlers/handlers.go
@@ -145,7 +145,7 @@ func handleSendError(r *request.Request, err error) {
 			r.HTTPResponse = &http.Response{
 				StatusCode: int(code),
 				Status:     http.StatusText(int(code)),
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+				Body:       io.NopCloser(bytes.NewReader([]byte{})),
 			}
 			return
 		}
@@ -156,7 +156,7 @@ func handleSendError(r *request.Request, err error) {
 		r.HTTPResponse = &http.Response{
 			StatusCode: int(0),
 			Status:     http.StatusText(int(0)),
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+			Body:       io.NopCloser(bytes.NewReader([]byte{})),
 		}
 	}
 	// Catch all other request errors.

--- a/vendor/github.com/aws/aws-sdk-go/aws/credentials/processcreds/provider.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/credentials/processcreds/provider.go
@@ -415,7 +415,7 @@ func executeCommand(cmd exec.Cmd, exec chan error) {
 func readInput(r io.Reader, w io.Writer, read chan error) {
 	tee := io.TeeReader(r, w)
 
-	_, err := ioutil.ReadAll(tee)
+	_, err := io.ReadAll(tee)
 
 	if err == io.EOF {
 		err = nil

--- a/vendor/github.com/aws/aws-sdk-go/aws/session/session.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/session/session.go
@@ -428,7 +428,7 @@ func loadCustomCABundle(s *Session, bundle io.Reader) error {
 }
 
 func loadCertPool(r io.Reader) (*x509.CertPool, error) {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return nil, awserr.New("LoadCustomCABundleError",
 			"failed to read custom CA bundle PEM file", err)

--- a/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/v4.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/v4.go
@@ -356,7 +356,7 @@ func (v4 Signer) signWithBody(r *http.Request, body io.ReadSeeker, service, regi
 		if body != nil {
 			var ok bool
 			if reader, ok = body.(io.ReadCloser); !ok {
-				reader = ioutil.NopCloser(body)
+				reader = io.NopCloser(body)
 			}
 		}
 		r.Body = reader

--- a/vendor/github.com/aws/aws-sdk-go/internal/ini/ini_lexer.go
+++ b/vendor/github.com/aws/aws-sdk-go/internal/ini/ini_lexer.go
@@ -57,7 +57,7 @@ type iniLexer struct{}
 // Tokenize will return a list of tokens during lexical analysis of the
 // io.Reader.
 func (l *iniLexer) Tokenize(r io.Reader) ([]Token, error) {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return nil, awserr.New(ErrCodeUnableToReadFile, "unable to read file", err)
 	}

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/payload.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/payload.go
@@ -32,7 +32,7 @@ func (h HandlerPayloadUnmarshal) UnmarshalPayload(r io.Reader, v interface{}) er
 		HTTPResponse: &http.Response{
 			StatusCode: 200,
 			Header:     http.Header{},
-			Body:       ioutil.NopCloser(r),
+			Body:       io.NopCloser(r),
 		},
 		Data: v,
 	}

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/query/unmarshal_error.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/query/unmarshal_error.go
@@ -26,7 +26,7 @@ var UnmarshalErrorHandler = request.NamedHandler{Name: "awssdk.query.UnmarshalEr
 func UnmarshalError(r *request.Request) {
 	defer r.HTTPResponse.Body.Close()
 
-	bodyBytes, err := ioutil.ReadAll(r.HTTPResponse.Body)
+	bodyBytes, err := io.ReadAll(r.HTTPResponse.Body)
 	if err != nil {
 		r.Error = awserr.NewRequestFailure(
 			awserr.New("SerializationError", "failed to read from query HTTP response body", err),

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/rest/unmarshal.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/rest/unmarshal.go
@@ -55,7 +55,7 @@ func unmarshalBody(r *request.Request, v reflect.Value) {
 					switch payload.Interface().(type) {
 					case []byte:
 						defer r.HTTPResponse.Body.Close()
-						b, err := ioutil.ReadAll(r.HTTPResponse.Body)
+						b, err := io.ReadAll(r.HTTPResponse.Body)
 						if err != nil {
 							r.Error = awserr.New("SerializationError", "failed to decode REST response", err)
 						} else {
@@ -63,7 +63,7 @@ func unmarshalBody(r *request.Request, v reflect.Value) {
 						}
 					case *string:
 						defer r.HTTPResponse.Body.Close()
-						b, err := ioutil.ReadAll(r.HTTPResponse.Body)
+						b, err := io.ReadAll(r.HTTPResponse.Body)
 						if err != nil {
 							r.Error = awserr.New("SerializationError", "failed to decode REST response", err)
 						} else {
@@ -75,15 +75,15 @@ func unmarshalBody(r *request.Request, v reflect.Value) {
 						case "io.ReadCloser":
 							payload.Set(reflect.ValueOf(r.HTTPResponse.Body))
 						case "io.ReadSeeker":
-							b, err := ioutil.ReadAll(r.HTTPResponse.Body)
+							b, err := io.ReadAll(r.HTTPResponse.Body)
 							if err != nil {
 								r.Error = awserr.New("SerializationError",
 									"failed to read response body", err)
 								return
 							}
-							payload.Set(reflect.ValueOf(ioutil.NopCloser(bytes.NewReader(b))))
+							payload.Set(reflect.ValueOf(io.NopCloser(bytes.NewReader(b))))
 						default:
-							io.Copy(ioutil.Discard, r.HTTPResponse.Body)
+							io.Copy(io.Discard, r.HTTPResponse.Body)
 							defer r.HTTPResponse.Body.Close()
 							r.Error = awserr.New("SerializationError",
 								"failed to decode REST response",

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/unmarshal.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/unmarshal.go
@@ -16,6 +16,6 @@ func UnmarshalDiscardBody(r *request.Request) {
 		return
 	}
 
-	io.Copy(ioutil.Discard, r.HTTPResponse.Body)
+	io.Copy(io.Discard, r.HTTPResponse.Body)
 	r.HTTPResponse.Body.Close()
 }

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/bucket_location.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/bucket_location.go
@@ -78,7 +78,7 @@ func WithNormalizeBucketLocation(r *request.Request) {
 func buildGetBucketLocation(r *request.Request) {
 	if r.DataFilled() {
 		out := r.Data.(*GetBucketLocationOutput)
-		b, err := ioutil.ReadAll(r.HTTPResponse.Body)
+		b, err := io.ReadAll(r.HTTPResponse.Body)
 		if err != nil {
 			r.Error = awserr.New("SerializationError", "failed reading response body", err)
 			return

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/statusok_error.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/statusok_error.go
@@ -11,7 +11,7 @@ import (
 )
 
 func copyMultipartStatusOKUnmarhsalError(r *request.Request) {
-	b, err := ioutil.ReadAll(r.HTTPResponse.Body)
+	b, err := io.ReadAll(r.HTTPResponse.Body)
 	if err != nil {
 		r.Error = awserr.NewRequestFailure(
 			awserr.New("SerializationError", "unable to read response body", err),
@@ -21,7 +21,7 @@ func copyMultipartStatusOKUnmarhsalError(r *request.Request) {
 		return
 	}
 	body := bytes.NewReader(b)
-	r.HTTPResponse.Body = ioutil.NopCloser(body)
+	r.HTTPResponse.Body = io.NopCloser(body)
 	defer body.Seek(0, sdkio.SeekStart)
 
 	if body.Len() == 0 {

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/unmarshal_error.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/unmarshal_error.go
@@ -21,7 +21,7 @@ type xmlErrorResponse struct {
 
 func unmarshalError(r *request.Request) {
 	defer r.HTTPResponse.Body.Close()
-	defer io.Copy(ioutil.Discard, r.HTTPResponse.Body)
+	defer io.Copy(io.Discard, r.HTTPResponse.Body)
 
 	// Bucket exists in a different region, and request needs
 	// to be made to the correct region.

--- a/vendor/github.com/bgentry/go-netrc/netrc/netrc.go
+++ b/vendor/github.com/bgentry/go-netrc/netrc/netrc.go
@@ -368,7 +368,7 @@ func scanValue(scanner *bufio.Scanner, pos int) ([]byte, string, int, error) {
 }
 
 func parse(r io.Reader, pos int) (*Netrc, error) {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/hashicorp/go-getter/client.go
+++ b/vendor/github.com/hashicorp/go-getter/client.go
@@ -157,7 +157,7 @@ func (c *Client) Get() error {
 	if decompressor != nil {
 		// Create a temporary directory to store our archive. We delete
 		// this at the end of everything.
-		td, err := ioutil.TempDir("", "getter")
+		td, err := os.MkdirTemp("", "getter")
 		if err != nil {
 			return fmt.Errorf(
 				"Error creating temporary directory for archive: %s", err)

--- a/vendor/github.com/hashicorp/go-getter/common.go
+++ b/vendor/github.com/hashicorp/go-getter/common.go
@@ -5,7 +5,7 @@ import (
 )
 
 func tmpFile(dir, pattern string) (string, error) {
-	f, err := ioutil.TempFile(dir, pattern)
+	f, err := os.CreateTemp(dir, pattern)
 	if err != nil {
 		return "", err
 	}

--- a/vendor/github.com/hashicorp/go-getter/decompress_testing.go
+++ b/vendor/github.com/hashicorp/go-getter/decompress_testing.go
@@ -34,7 +34,7 @@ func TestDecompressor(t testing.T, d Decompressor, cases []TestDecompressCase) {
 		t.Logf("Testing: %s", tc.Input)
 
 		// Temporary dir to store stuff
-		td, err := ioutil.TempDir("", "getter")
+		td, err := os.MkdirTemp("", "getter")
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}

--- a/vendor/github.com/hashicorp/go-getter/get_git.go
+++ b/vendor/github.com/hashicorp/go-getter/get_git.go
@@ -79,7 +79,7 @@ func (g *GitGetter) Get(dst string, u *url.URL) error {
 		}
 
 		// Create a temp file for the key and ensure it is removed.
-		fh, err := ioutil.TempFile("", "go-getter")
+		fh, err := os.CreateTemp("", "go-getter")
 		if err != nil {
 			return err
 		}

--- a/vendor/github.com/hashicorp/go-hclog/nulllogger.go
+++ b/vendor/github.com/hashicorp/go-hclog/nulllogger.go
@@ -43,5 +43,5 @@ func (l *nullLogger) ResetNamed(name string) Logger { return l }
 func (l *nullLogger) SetLevel(level Level) {}
 
 func (l *nullLogger) StandardLogger(opts *StandardLoggerOptions) *log.Logger {
-	return log.New(ioutil.Discard, "", log.LstdFlags)
+	return log.New(io.Discard, "", log.LstdFlags)
 }

--- a/vendor/github.com/hashicorp/go-plugin/client.go
+++ b/vendor/github.com/hashicorp/go-plugin/client.go
@@ -299,14 +299,14 @@ func NewClient(config *ClientConfig) (c *Client) {
 	}
 
 	if config.Stderr == nil {
-		config.Stderr = ioutil.Discard
+		config.Stderr = io.Discard
 	}
 
 	if config.SyncStdout == nil {
-		config.SyncStdout = ioutil.Discard
+		config.SyncStdout = io.Discard
 	}
 	if config.SyncStderr == nil {
-		config.SyncStderr = ioutil.Discard
+		config.SyncStderr = io.Discard
 	}
 
 	if config.AllowedProtocols == nil {

--- a/vendor/github.com/hashicorp/go-plugin/server.go
+++ b/vendor/github.com/hashicorp/go-plugin/server.go
@@ -385,7 +385,7 @@ func serverListener_tcp() (net.Listener, error) {
 }
 
 func serverListener_unix() (net.Listener, error) {
-	tf, err := ioutil.TempFile("", "plugin")
+	tf, err := os.CreateTemp("", "plugin")
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/hashicorp/go-safetemp/safetemp.go
+++ b/vendor/github.com/hashicorp/go-safetemp/safetemp.go
@@ -23,7 +23,7 @@ import (
 // be nil).
 func Dir(dir, prefix string) (string, io.Closer, error) {
 	// Create the temporary directory
-	td, err := ioutil.TempDir(dir, prefix)
+	td, err := os.MkdirTemp(dir, prefix)
 	if err != nil {
 		return "", nil, err
 	}

--- a/vendor/github.com/hashicorp/hcl2/hcl/json/public.go
+++ b/vendor/github.com/hashicorp/hcl2/hcl/json/public.go
@@ -79,7 +79,7 @@ func ParseFile(filename string) (*hcl.File, hcl.Diagnostics) {
 	}
 	defer f.Close()
 
-	src, err := ioutil.ReadAll(f)
+	src, err := io.ReadAll(f)
 	if err != nil {
 		return nil, hcl.Diagnostics{
 			{

--- a/vendor/github.com/hashicorp/hcl2/hclparse/parser.go
+++ b/vendor/github.com/hashicorp/hcl2/hclparse/parser.go
@@ -55,7 +55,7 @@ func (p *Parser) ParseHCLFile(filename string) (*hcl.File, hcl.Diagnostics) {
 		return existing, nil
 	}
 
-	src, err := ioutil.ReadFile(filename)
+	src, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, hcl.Diagnostics{
 			{

--- a/vendor/github.com/hashicorp/terraform-config-inspect/tfconfig/load.go
+++ b/vendor/github.com/hashicorp/terraform-config-inspect/tfconfig/load.go
@@ -68,7 +68,7 @@ func (m *Module) init(diags Diagnostics) {
 }
 
 func dirFiles(dir string) (primary []string, diags hcl.Diagnostics) {
-	infos, err := ioutil.ReadDir(dir)
+	infos, err := os.ReadDir(dir)
 	if err != nil {
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,

--- a/vendor/github.com/hashicorp/terraform-config-inspect/tfconfig/load_legacy.go
+++ b/vendor/github.com/hashicorp/terraform-config-inspect/tfconfig/load_legacy.go
@@ -22,7 +22,7 @@ func loadModuleLegacyHCL(dir string) (*Module, Diagnostics) {
 	}
 
 	for _, filename := range primaryPaths {
-		src, err := ioutil.ReadFile(filename)
+		src, err := os.ReadFile(filename)
 		if err != nil {
 			return mod, diagnosticsErrorf("Error reading %s: %s", filename, err)
 		}

--- a/vendor/github.com/hashicorp/terraform/config/interpolate_funcs.go
+++ b/vendor/github.com/hashicorp/terraform/config/interpolate_funcs.go
@@ -466,7 +466,7 @@ func interpolationFuncFile() ast.Function {
 			if err != nil {
 				return "", err
 			}
-			data, err := ioutil.ReadFile(path)
+			data, err := os.ReadFile(path)
 			if err != nil {
 				return "", err
 			}

--- a/vendor/github.com/hashicorp/terraform/config/loader_hcl.go
+++ b/vendor/github.com/hashicorp/terraform/config/loader_hcl.go
@@ -172,7 +172,7 @@ func (t *hclConfigurable) Config() (*Config, error) {
 // files and turn them into hclConfigurables.
 func loadFileHcl(root string) (configurable, []string, error) {
 	// Read the HCL file and prepare for parsing
-	d, err := ioutil.ReadFile(root)
+	d, err := os.ReadFile(root)
 	if err != nil {
 		return nil, nil, fmt.Errorf(
 			"Error reading %s: %s", root, err)

--- a/vendor/github.com/hashicorp/terraform/config/module/get.go
+++ b/vendor/github.com/hashicorp/terraform/config/module/get.go
@@ -34,7 +34,7 @@ const (
 // can't be updated on its own.
 func GetCopy(dst, src string) error {
 	// Create the temporary directory to do the real Get to
-	tmpDir, err := ioutil.TempDir("", "tf")
+	tmpDir, err := os.MkdirTemp("", "tf")
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/hashicorp/terraform/config/module/storage.go
+++ b/vendor/github.com/hashicorp/terraform/config/module/storage.go
@@ -88,7 +88,7 @@ func (s Storage) loadManifest() (moduleManifest, error) {
 	manifest := moduleManifest{}
 
 	manifestPath := filepath.Join(s.StorageDir, manifestName)
-	data, err := ioutil.ReadFile(manifestPath)
+	data, err := os.ReadFile(manifestPath)
 	if err != nil && !os.IsNotExist(err) {
 		return manifest, err
 	}
@@ -138,7 +138,7 @@ func (s Storage) recordModule(rec moduleRecord) error {
 	}
 
 	manifestPath := filepath.Join(s.StorageDir, manifestName)
-	return ioutil.WriteFile(manifestPath, js, 0644)
+	return os.WriteFile(manifestPath, js, 0644)
 }
 
 // load the manifest from dir, and return all module versions matching the

--- a/vendor/github.com/hashicorp/terraform/config/module/testing.go
+++ b/vendor/github.com/hashicorp/terraform/config/module/testing.go
@@ -10,7 +10,7 @@ import (
 // as a function that should be deferred to clean up resources.
 func TestTree(t *testing.T, path string) (*Tree, func()) {
 	// Create a temporary directory for module storage
-	dir, err := ioutil.TempDir("", "tf")
+	dir, err := os.MkdirTemp("", "tf")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 		return nil, nil

--- a/vendor/github.com/hashicorp/terraform/configs/configload/testing.go
+++ b/vendor/github.com/hashicorp/terraform/configs/configload/testing.go
@@ -20,7 +20,7 @@ import (
 func NewLoaderForTests(t *testing.T) (*Loader, func()) {
 	t.Helper()
 
-	modulesDir, err := ioutil.TempDir("", "tf-configs")
+	modulesDir, err := os.MkdirTemp("", "tf-configs")
 	if err != nil {
 		t.Fatalf("failed to create temporary modules dir: %s", err)
 		return nil, func() {}

--- a/vendor/github.com/hashicorp/terraform/helper/logging/logging.go
+++ b/vendor/github.com/hashicorp/terraform/helper/logging/logging.go
@@ -22,7 +22,7 @@ var ValidLevels = []logutils.LogLevel{"TRACE", "DEBUG", "INFO", "WARN", "ERROR"}
 
 // LogOutput determines where we should send logs (if anywhere) and the log level.
 func LogOutput() (logOutput io.Writer, err error) {
-	logOutput = ioutil.Discard
+	logOutput = io.Discard
 
 	logLevel := LogLevel()
 	if logLevel == "" {
@@ -58,7 +58,7 @@ func SetOutput() {
 	}
 
 	if out == nil {
-		out = ioutil.Discard
+		out = io.Discard
 	}
 
 	log.SetOutput(out)

--- a/vendor/github.com/hashicorp/terraform/helper/resource/testing.go
+++ b/vendor/github.com/hashicorp/terraform/helper/resource/testing.go
@@ -393,7 +393,7 @@ type TestStep struct {
 const EnvLogPathMask = "TF_LOG_PATH_MASK"
 
 func LogOutput(t TestT) (logOutput io.Writer, err error) {
-	logOutput = ioutil.Discard
+	logOutput = io.Discard
 
 	logLevel := logging.LogLevel()
 	if logLevel == "" {
@@ -809,7 +809,7 @@ func testConfig(opts terraform.ContextOpts, step TestStep) (*configs.Config, err
 		step.PreConfig()
 	}
 
-	cfgPath, err := ioutil.TempDir("", "tf-test")
+	cfgPath, err := os.MkdirTemp("", "tf-test")
 	if err != nil {
 		return nil, fmt.Errorf("Error creating temporary directory for config: %s", err)
 	}
@@ -821,7 +821,7 @@ func testConfig(opts terraform.ContextOpts, step TestStep) (*configs.Config, err
 	}
 
 	// Write the main configuration file
-	err = ioutil.WriteFile(filepath.Join(cfgPath, "main.tf"), []byte(step.Config), os.ModePerm)
+	err = os.WriteFile(filepath.Join(cfgPath, "main.tf"), []byte(step.Config), os.ModePerm)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating temporary file for config: %s", err)
 	}

--- a/vendor/github.com/hashicorp/terraform/internal/initwd/from_module.go
+++ b/vendor/github.com/hashicorp/terraform/internal/initwd/from_module.go
@@ -48,7 +48,7 @@ func DirFromModule(rootDir, modulesDir, sourceAddr string, reg *registry.Client,
 
 	// The target directory must exist but be empty.
 	{
-		entries, err := ioutil.ReadDir(rootDir)
+		entries, err := os.ReadDir(rootDir)
 		if err != nil {
 			if os.IsNotExist(err) {
 				diags = diags.Append(tfdiags.Sourceless(

--- a/vendor/github.com/hashicorp/terraform/internal/modsdir/manifest.go
+++ b/vendor/github.com/hashicorp/terraform/internal/modsdir/manifest.go
@@ -59,7 +59,7 @@ type manifestSnapshotFile struct {
 }
 
 func ReadManifestSnapshot(r io.Reader) (Manifest, error) {
-	src, err := ioutil.ReadAll(r)
+	src, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/hashicorp/terraform/lang/funcs/filesystem.go
+++ b/vendor/github.com/hashicorp/terraform/lang/funcs/filesystem.go
@@ -266,7 +266,7 @@ func readFileBytes(baseDir, path string) ([]byte, error) {
 	// Ensure that the path is canonical for the host OS
 	path = filepath.Clean(path)
 
-	src, err := ioutil.ReadFile(path)
+	src, err := os.ReadFile(path)
 	if err != nil {
 		// ReadFile does not return Terraform-user-friendly error
 		// messages, so we'll provide our own.

--- a/vendor/github.com/hashicorp/terraform/plugin/discovery/find.go
+++ b/vendor/github.com/hashicorp/terraform/plugin/discovery/find.go
@@ -48,7 +48,7 @@ func findPluginPaths(kind string, dirs []string) []string {
 	ret := make([]string, 0, len(dirs))
 
 	for _, dir := range dirs {
-		items, err := ioutil.ReadDir(dir)
+		items, err := os.ReadDir(dir)
 		if err != nil {
 			// Ignore missing dirs, non-dirs, etc
 			continue

--- a/vendor/github.com/hashicorp/terraform/plugin/discovery/get.go
+++ b/vendor/github.com/hashicorp/terraform/plugin/discovery/get.go
@@ -642,7 +642,7 @@ func getFile(url string) ([]byte, error) {
 		return nil, fmt.Errorf("%s", resp.Status)
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return data, err
 	}

--- a/vendor/github.com/hashicorp/terraform/registry/client.go
+++ b/vendor/github.com/hashicorp/terraform/registry/client.go
@@ -183,7 +183,7 @@ func (c *Client) ModuleLocation(module *regsrc.Module, version string) (string, 
 	defer resp.Body.Close()
 
 	// there should be no body, but save it for logging
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("error reading response body from registry: %s", err)
 	}

--- a/vendor/github.com/hashicorp/terraform/states/statefile/read.go
+++ b/vendor/github.com/hashicorp/terraform/states/statefile/read.go
@@ -38,7 +38,7 @@ func Read(r io.Reader) (*File, error) {
 	// We actually just buffer the whole thing in memory, because states are
 	// generally not huge and we need to do be able to sniff for a version
 	// number before full parsing.
-	src, err := ioutil.ReadAll(r)
+	src, err := io.ReadAll(r)
 	if err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,

--- a/vendor/github.com/hashicorp/terraform/svchost/disco/disco.go
+++ b/vendor/github.com/hashicorp/terraform/svchost/disco/disco.go
@@ -232,7 +232,7 @@ func (d *Disco) discover(hostname svchost.Hostname) (*Host, error) {
 	// size, but we'll at least prevent reading the entire thing into memory.
 	lr := io.LimitReader(resp.Body, maxDiscoDocBytes)
 
-	servicesBytes, err := ioutil.ReadAll(lr)
+	servicesBytes, err := io.ReadAll(lr)
 	if err != nil {
 		return nil, fmt.Errorf("Error reading discovery document body: %v", err)
 	}

--- a/vendor/github.com/hashicorp/terraform/terraform/state.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/state.go
@@ -1956,7 +1956,7 @@ func ReadState(src io.Reader) (*State, error) {
 
 	// If we are JSON we buffer the whole thing in memory so we can read it twice.
 	// This is suboptimal, but will work for now.
-	jsonBytes, err := ioutil.ReadAll(buf)
+	jsonBytes, err := io.ReadAll(buf)
 	if err != nil {
 		return nil, fmt.Errorf("Reading state file failed: %v", err)
 	}

--- a/vendor/github.com/hashicorp/yamux/session.go
+++ b/vendor/github.com/hashicorp/yamux/session.go
@@ -495,7 +495,7 @@ func (s *Session) handleStreamMessage(hdr header) error {
 		// Drain any data on the wire
 		if hdr.MsgType() == typeData && hdr.Length() > 0 {
 			s.logger.Printf("[WARN] yamux: Discarding data for stream: %d", id)
-			if _, err := io.CopyN(ioutil.Discard, s.bufRead, int64(hdr.Length())); err != nil {
+			if _, err := io.CopyN(io.Discard, s.bufRead, int64(hdr.Length())); err != nil {
 				s.logger.Printf("[ERR] yamux: Failed to discard data: %v", err)
 				return nil
 			}

--- a/vendor/github.com/posener/complete/cmd/install/utils.go
+++ b/vendor/github.com/posener/complete/cmd/install/utils.go
@@ -90,7 +90,7 @@ func removeContentToTempFile(name, content string) (string, error) {
 		return "", err
 	}
 	defer rf.Close()
-	wf, err := ioutil.TempFile("/tmp", "complete-")
+	wf, err := os.CreateTemp("/tmp", "complete-")
 	if err != nil {
 		return "", err
 	}

--- a/vendor/github.com/posener/complete/log.go
+++ b/vendor/github.com/posener/complete/log.go
@@ -14,7 +14,7 @@ import (
 var Log = getLogger()
 
 func getLogger() func(format string, args ...interface{}) {
-	var logfile = ioutil.Discard
+	var logfile = io.Discard
 	if os.Getenv(envDebug) != "" {
 		logfile = os.Stderr
 	}

--- a/vendor/github.com/posener/complete/predict_files.go
+++ b/vendor/github.com/posener/complete/predict_files.go
@@ -92,7 +92,7 @@ func listFiles(dir, pattern string, allowFiles bool) []string {
 	}
 
 	// list directories
-	if dirs, err := ioutil.ReadDir(dir); err == nil {
+	if dirs, err := os.ReadDir(dir); err == nil {
 		for _, d := range dirs {
 			if d.IsDir() {
 				m[filepath.Join(dir, d.Name())] = true

--- a/vendor/golang.org/x/crypto/openpgp/packet/opaque.go
+++ b/vendor/golang.org/x/crypto/openpgp/packet/opaque.go
@@ -26,7 +26,7 @@ type OpaquePacket struct {
 }
 
 func (op *OpaquePacket) parse(r io.Reader) (err error) {
-	op.Contents, err = ioutil.ReadAll(r)
+	op.Contents, err = io.ReadAll(r)
 	return
 }
 

--- a/vendor/golang.org/x/crypto/openpgp/packet/private_key.go
+++ b/vendor/golang.org/x/crypto/openpgp/packet/private_key.go
@@ -133,7 +133,7 @@ func (pk *PrivateKey) parse(r io.Reader) (err error) {
 		}
 	}
 
-	pk.encryptedData, err = ioutil.ReadAll(r)
+	pk.encryptedData, err = io.ReadAll(r)
 	if err != nil {
 		return
 	}

--- a/vendor/golang.org/x/crypto/openpgp/packet/userattribute.go
+++ b/vendor/golang.org/x/crypto/openpgp/packet/userattribute.go
@@ -56,7 +56,7 @@ func NewUserAttribute(contents ...*OpaqueSubpacket) *UserAttribute {
 
 func (uat *UserAttribute) parse(r io.Reader) (err error) {
 	// RFC 4880, section 5.13
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return
 	}

--- a/vendor/golang.org/x/crypto/openpgp/packet/userid.go
+++ b/vendor/golang.org/x/crypto/openpgp/packet/userid.go
@@ -66,7 +66,7 @@ func NewUserId(name, comment, email string) *UserId {
 
 func (uid *UserId) parse(r io.Reader) (err error) {
 	// RFC 4880, section 5.11
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return
 	}

--- a/vendor/golang.org/x/net/http2/transport.go
+++ b/vendor/golang.org/x/net/http2/transport.go
@@ -2388,7 +2388,7 @@ func (t *Transport) logf(format string, args ...interface{}) {
 	log.Printf(format, args...)
 }
 
-var noBody io.ReadCloser = ioutil.NopCloser(bytes.NewReader(nil))
+var noBody io.ReadCloser = io.NopCloser(bytes.NewReader(nil))
 
 func strSliceContains(ss []string, s string) bool {
 	for _, v := range ss {

--- a/vendor/golang.org/x/oauth2/google/default.go
+++ b/vendor/golang.org/x/oauth2/google/default.go
@@ -147,7 +147,7 @@ func wellKnownFile() string {
 }
 
 func readCredentialsFile(ctx context.Context, filename string, scopes []string) (*DefaultCredentials, error) {
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/golang.org/x/oauth2/internal/token.go
+++ b/vendor/golang.org/x/oauth2/internal/token.go
@@ -233,7 +233,7 @@ func doTokenRoundTrip(ctx context.Context, req *http.Request) (*Token, error) {
 	if err != nil {
 		return nil, err
 	}
-	body, err := ioutil.ReadAll(io.LimitReader(r.Body, 1<<20))
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 	r.Body.Close()
 	if err != nil {
 		return nil, fmt.Errorf("oauth2: cannot fetch token: %v", err)

--- a/vendor/golang.org/x/oauth2/jwt/jwt.go
+++ b/vendor/golang.org/x/oauth2/jwt/jwt.go
@@ -127,7 +127,7 @@ func (js jwtSource) Token() (*oauth2.Token, error) {
 		return nil, fmt.Errorf("oauth2: cannot fetch token: %v", err)
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return nil, fmt.Errorf("oauth2: cannot fetch token: %v", err)
 	}

--- a/vendor/golang.org/x/sys/unix/mkasm_darwin.go
+++ b/vendor/golang.org/x/sys/unix/mkasm_darwin.go
@@ -18,16 +18,16 @@ import (
 )
 
 func main() {
-	in1, err := ioutil.ReadFile("syscall_darwin.go")
+	in1, err := os.ReadFile("syscall_darwin.go")
 	if err != nil {
 		log.Fatalf("can't open syscall_darwin.go: %s", err)
 	}
 	arch := os.Args[1]
-	in2, err := ioutil.ReadFile(fmt.Sprintf("syscall_darwin_%s.go", arch))
+	in2, err := os.ReadFile(fmt.Sprintf("syscall_darwin_%s.go", arch))
 	if err != nil {
 		log.Fatalf("can't open syscall_darwin_%s.go: %s", arch, err)
 	}
-	in3, err := ioutil.ReadFile(fmt.Sprintf("zsyscall_darwin_%s.go", arch))
+	in3, err := os.ReadFile(fmt.Sprintf("zsyscall_darwin_%s.go", arch))
 	if err != nil {
 		log.Fatalf("can't open zsyscall_darwin_%s.go: %s", arch, err)
 	}
@@ -54,7 +54,7 @@ func main() {
 			fmt.Fprintf(&out, "\tJMP\t%s(SB)\n", fn)
 		}
 	}
-	err = ioutil.WriteFile(fmt.Sprintf("zsyscall_darwin_%s.s", arch), out.Bytes(), 0644)
+	err = os.WriteFile(fmt.Sprintf("zsyscall_darwin_%s.s", arch), out.Bytes(), 0644)
 	if err != nil {
 		log.Fatalf("can't write zsyscall_darwin_%s.s: %s", arch, err)
 	}

--- a/vendor/golang.org/x/sys/unix/mkpost.go
+++ b/vendor/golang.org/x/sys/unix/mkpost.go
@@ -37,7 +37,7 @@ func main() {
 		}
 	}
 
-	b, err := ioutil.ReadAll(os.Stdin)
+	b, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/vendor/golang.org/x/sys/unix/mksyscall_aix_ppc64.go
+++ b/vendor/golang.org/x/sys/unix/mksyscall_aix_ppc64.go
@@ -521,7 +521,7 @@ func main() {
 	}
 
 	// Print zsyscall_aix_ppc64.go
-	err := ioutil.WriteFile("zsyscall_aix_ppc64.go",
+	err := os.WriteFile("zsyscall_aix_ppc64.go",
 		[]byte(fmt.Sprintf(srcTemplate1, cmdLine(), buildTags(), pack, imp, textcommon)),
 		0644)
 	if err != nil {
@@ -532,7 +532,7 @@ func main() {
 	// Print zsyscall_aix_ppc64_gc.go
 	vardecls := "\t" + strings.Join(vars, ",\n\t")
 	vardecls += " syscallFunc"
-	err = ioutil.WriteFile("zsyscall_aix_ppc64_gc.go",
+	err = os.WriteFile("zsyscall_aix_ppc64_gc.go",
 		[]byte(fmt.Sprintf(srcTemplate2, cmdLine(), buildTags(), pack, imp, dynimports, linknames, vardecls, textgc)),
 		0644)
 	if err != nil {
@@ -541,7 +541,7 @@ func main() {
 	}
 
 	// Print zsyscall_aix_ppc64_gccgo.go
-	err = ioutil.WriteFile("zsyscall_aix_ppc64_gccgo.go",
+	err = os.WriteFile("zsyscall_aix_ppc64_gccgo.go",
 		[]byte(fmt.Sprintf(srcTemplate3, cmdLine(), buildTags(), pack, cExtern, imp, textgccgo)),
 		0644)
 	if err != nil {

--- a/vendor/golang.org/x/sys/unix/mksysnum.go
+++ b/vendor/golang.org/x/sys/unix/mksysnum.go
@@ -62,7 +62,7 @@ func fetchFile(URL string) io.Reader {
 	resp, err := http.Get(URL)
 	checkErr(err)
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	checkErr(err)
 	return strings.NewReader(string(body))
 }

--- a/vendor/google.golang.org/api/gensupport/media.go
+++ b/vendor/google.golang.org/api/gensupport/media.go
@@ -61,7 +61,7 @@ func (cs *contentSniffer) ContentType() (string, bool) {
 	}
 	cs.sniffed = true
 	// If ReadAll hits EOF, it returns err==nil.
-	cs.start, cs.err = ioutil.ReadAll(io.LimitReader(cs.r, sniffBuffSize))
+	cs.start, cs.err = io.ReadAll(io.LimitReader(cs.r, sniffBuffSize))
 
 	// Don't try to detect the content type based on possibly incomplete data.
 	if cs.err != nil {
@@ -282,8 +282,8 @@ func (mi *MediaInfo) UploadRequest(reqHeaders http.Header, body io.Reader) (newB
 		combined, ctype := CombineBodyMedia(body, "application/json", media, mi.mType)
 		if fb != nil && fm != nil {
 			getBody = func() (io.ReadCloser, error) {
-				rb := ioutil.NopCloser(fb())
-				rm := ioutil.NopCloser(fm())
+				rb := io.NopCloser(fb())
+				rm := io.NopCloser(fm())
 				r, _ := CombineBodyMedia(rb, "application/json", rm, mi.mType)
 				return r, nil
 			}

--- a/vendor/google.golang.org/api/googleapi/googleapi.go
+++ b/vendor/google.golang.org/api/googleapi/googleapi.go
@@ -119,7 +119,7 @@ func CheckResponse(res *http.Response) error {
 	if res.StatusCode >= 200 && res.StatusCode <= 299 {
 		return nil
 	}
-	slurp, err := ioutil.ReadAll(res.Body)
+	slurp, err := io.ReadAll(res.Body)
 	if err == nil {
 		jerr := new(errorReply)
 		err = json.Unmarshal(slurp, jerr)
@@ -158,7 +158,7 @@ func CheckMediaResponse(res *http.Response) error {
 	if res.StatusCode >= 200 && res.StatusCode <= 299 {
 		return nil
 	}
-	slurp, _ := ioutil.ReadAll(io.LimitReader(res.Body, 1<<20))
+	slurp, _ := io.ReadAll(io.LimitReader(res.Body, 1<<20))
 	return &Error{
 		Code: res.StatusCode,
 		Body: string(slurp),

--- a/vendor/google.golang.org/api/internal/creds.go
+++ b/vendor/google.golang.org/api/internal/creds.go
@@ -32,7 +32,7 @@ func Creds(ctx context.Context, ds *DialSettings) (*google.DefaultCredentials, e
 		return google.CredentialsFromJSON(ctx, ds.CredentialsJSON, ds.Scopes...)
 	}
 	if ds.CredentialsFile != "" {
-		data, err := ioutil.ReadFile(ds.CredentialsFile)
+		data, err := os.ReadFile(ds.CredentialsFile)
 		if err != nil {
 			return nil, fmt.Errorf("cannot read credentials file: %v", err)
 		}

--- a/vendor/google.golang.org/appengine/internal/api.go
+++ b/vendor/google.golang.org/appengine/internal/api.go
@@ -390,7 +390,7 @@ func (c *context) post(body []byte, timeout time.Duration) (b []byte, err error)
 			apiContentType:    apiContentTypeValue,
 			apiDeadlineHeader: []string{strconv.FormatFloat(timeout.Seconds(), 'f', -1, 64)},
 		},
-		Body:          ioutil.NopCloser(bytes.NewReader(body)),
+		Body:          io.NopCloser(bytes.NewReader(body)),
 		ContentLength: int64(len(body)),
 		Host:          c.apiURL.Host,
 	}
@@ -424,7 +424,7 @@ func (c *context) post(body []byte, timeout time.Duration) (b []byte, err error)
 		}
 	}
 	defer hresp.Body.Close()
-	hrespBody, err := ioutil.ReadAll(hresp.Body)
+	hrespBody, err := io.ReadAll(hresp.Body)
 	if hresp.StatusCode != 200 {
 		return nil, &CallError{
 			Detail: fmt.Sprintf("service bridge returned HTTP %d (%q)", hresp.StatusCode, hrespBody),

--- a/vendor/google.golang.org/appengine/internal/metadata.go
+++ b/vendor/google.golang.org/appengine/internal/metadata.go
@@ -56,5 +56,5 @@ func getMetadata(key string) ([]byte, error) {
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("metadata server returned HTTP %d", resp.StatusCode)
 	}
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }

--- a/vendor/google.golang.org/appengine/urlfetch/urlfetch.go
+++ b/vendor/google.golang.org/appengine/urlfetch/urlfetch.go
@@ -158,7 +158,7 @@ func (t *Transport) RoundTrip(req *http.Request) (res *http.Response, err error)
 		}:
 			freq.Payload = b.Bytes()
 		default:
-			freq.Payload, err = ioutil.ReadAll(req.Body)
+			freq.Payload, err = io.ReadAll(req.Body)
 			if err != nil {
 				return nil, err
 			}

--- a/vendor/google.golang.org/grpc/credentials/credentials.go
+++ b/vendor/google.golang.org/grpc/credentials/credentials.go
@@ -226,7 +226,7 @@ func NewClientTLSFromCert(cp *x509.CertPool, serverNameOverride string) Transpor
 // serverNameOverride is for testing only. If set to a non empty string,
 // it will override the virtual host name of authority (e.g. :authority header field) in requests.
 func NewClientTLSFromFile(certFile, serverNameOverride string) (TransportCredentials, error) {
-	b, err := ioutil.ReadFile(certFile)
+	b, err := os.ReadFile(certFile)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/google.golang.org/grpc/grpclog/loggerv2.go
+++ b/vendor/google.golang.org/grpc/grpclog/loggerv2.go
@@ -117,9 +117,9 @@ func NewLoggerV2WithVerbosity(infoW, warningW, errorW io.Writer, v int) LoggerV2
 // newLoggerV2 creates a loggerV2 to be used as default logger.
 // All logs are written to stderr.
 func newLoggerV2() LoggerV2 {
-	errorW := ioutil.Discard
-	warningW := ioutil.Discard
-	infoW := ioutil.Discard
+	errorW := io.Discard
+	warningW := io.Discard
+	infoW := io.Discard
 
 	logLevel := os.Getenv("GRPC_GO_LOG_SEVERITY_LEVEL")
 	switch logLevel {

--- a/vendor/google.golang.org/grpc/internal/binarylog/sink.go
+++ b/vendor/google.golang.org/grpc/internal/binarylog/sink.go
@@ -154,7 +154,7 @@ func newBufWriteCloserSink(o io.WriteCloser) Sink {
 // NewTempFileSink creates a temp file and returns a Sink that writes to this
 // file.
 func NewTempFileSink() (Sink, error) {
-	tempFile, err := ioutil.TempFile("/tmp", "grpcgo_binarylog_*.txt")
+	tempFile, err := os.CreateTemp("/tmp", "grpcgo_binarylog_*.txt")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp file: %v", err)
 	}

--- a/vendor/google.golang.org/grpc/rpc_util.go
+++ b/vendor/google.golang.org/grpc/rpc_util.go
@@ -78,7 +78,7 @@ func NewGZIPCompressorWithLevel(level int) (Compressor, error) {
 	return &gzipCompressor{
 		pool: sync.Pool{
 			New: func() interface{} {
-				w, err := gzip.NewWriterLevel(ioutil.Discard, level)
+				w, err := gzip.NewWriterLevel(io.Discard, level)
 				if err != nil {
 					panic(err)
 				}
@@ -144,7 +144,7 @@ func (d *gzipDecompressor) Do(r io.Reader) ([]byte, error) {
 		z.Close()
 		d.pool.Put(z)
 	}()
-	return ioutil.ReadAll(z)
+	return io.ReadAll(z)
 }
 
 func (d *gzipDecompressor) Type() string {
@@ -636,7 +636,7 @@ func recvAndDecompress(p *parser, s *transport.Stream, dc Decompressor, maxRecei
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "grpc: failed to decompress the received message %v", err)
 			}
-			d, err = ioutil.ReadAll(dcReader)
+			d, err = io.ReadAll(dcReader)
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "grpc: failed to decompress the received message %v", err)
 			}


### PR DESCRIPTION
Removes usage of the deprecated ioutil package as described [here](https://golang.org/doc/go1.16#ioutil)

[_Created by Sourcegraph batch change `rslade/deprecate-ioutil`._](https://k8s.sgdev.org/users/rslade/batch-changes/deprecate-ioutil)